### PR TITLE
resolved token vs. character indexing issues

### DIFF
--- a/spacyfishing/entity_fishing_linker.py
+++ b/spacyfishing/entity_fishing_linker.py
@@ -196,8 +196,8 @@ class EntityFishing:
                 "entities": [
                     {
                         "rawName": ent.text,
-                        "offsetStart": ent.start,
-                        "offsetEnd": ent.end,
+                        "offsetStart": ent.start_char,
+                        "offsetEnd": ent.end_char,
                     } for ent in entities
                 ],
                 "mentions": [],


### PR DESCRIPTION
Added character indexing, instead of the faulty, token based indexing. Note that doc.[index_x, index_y] refers to token, however, entity-fishing works with characters.
Additionally, now you also assign the entity_fishing variables to completely different spans, which will also likely overlap with one another.