### PR TITLE
added more lenient requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-spacy>=3.3.1
-requests>=2.28.0
+spacy>=3.2
+requests>=2.20

--- a/spacyfishing/entity_fishing_linker.py
+++ b/spacyfishing/entity_fishing_linker.py
@@ -184,7 +184,7 @@ class EntityFishing:
         """
         try:
             res_json = response.json()
-        except requests.exceptions.JSONDecodeError:
+        except json.decoder.JSONDecodeError:
             res_json = {}
 
         metadata = {
@@ -342,7 +342,7 @@ class EntityFishing:
             span._.other_ids = ids
         except KeyError:
             pass
-        except requests.exceptions.JSONDecodeError:
+        except json.decoder.JSONDecodeError:
             pass
 
     def main_disambiguation_process_batch(self,


### PR DESCRIPTION
I just tried installing `spacyfishing` with a package that required `requests` version from 2.2 > 2.28, and found that the current version of `spacyfishing` only support the most recent version >=2.28.1. I believe more lenient requirements for both `spaCy` and `requests` are desirable for production purposes.